### PR TITLE
Settlement: rebase fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@
 - fix: Change serialization of bitvec to &[u8] in merkle tree to avoid memory
   uninitialized
 - chore: change SCARB config version for foundry CI
-- fix(node/commands): md5 are aslo checked when running setup --from-local
+- fix(node/commands): md5 are also checked when running setup --from-local
 - feat(data-availability): extend eth config with poll interval
 - fix(snos-output): expose snos codec, remove unused `get_starknet_messages`
   runtime method, and unnecessary mp-snos-output dependencies
-- feat(program-hash): add new pallete constant for Starknet OS progam hash;
+- feat(program-hash): add new pallet constant for Starknet OS progam hash;
   expose runtime getter method; add dedicated crate to manage versions
 - feat(runtime): expose fee token address getter method
 - feat(settlement): run client thread responsible for pushing state updates and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6829,6 +6829,7 @@ dependencies = [
  "mp-messages",
  "mp-transactions",
  "parity-scale-codec",
+ "pretty_assertions",
  "scale-info",
  "sp-core 21.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.3.0)",
  "starknet_api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,14 +3172,29 @@ version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5344eea9b20effb5efeaad29418215c4d27017639fd1f908260f59cbbd226e"
 dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
+ "ethers-addressbook 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-etherscan 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-middleware 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-solc 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethers"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "ethers-addressbook 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-contract 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-etherscan 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-middleware 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-providers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-signers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-solc 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
 ]
 
 [[package]]
@@ -3188,7 +3203,18 @@ version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c405f24ea3a517899ba7985385c43dc4a7eb1209af3b1e0a1a32d7dcc7f8d09"
 dependencies = [
- "ethers-core",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "once_cell",
  "serde",
  "serde_json",
@@ -3201,10 +3227,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0111ead599d17a7bff6985fd5756f39ca7033edc79a31b23026a8d5d64fa95cd"
 dependencies = [
  "const-hex",
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
+ "ethers-contract-abigen 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract-derive 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "const-hex",
+ "ethers-contract-abigen 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-contract-derive 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-providers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "futures-util",
  "once_cell",
  "pin-project",
@@ -3222,8 +3266,31 @@ dependencies = [
  "Inflector",
  "const-hex",
  "dunce",
- "ethers-core",
- "ethers-etherscan",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-etherscan 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eyre",
+ "prettyplease 0.2.15",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn 2.0.40",
+ "toml 0.8.8",
+ "walkdir",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "dunce",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-etherscan 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "eyre",
  "prettyplease 0.2.15",
  "proc-macro2",
@@ -3245,8 +3312,23 @@ checksum = "936e7a0f1197cee2b62dc89f63eff3201dbf87c283ff7e18d86d38f83b845483"
 dependencies = [
  "Inflector",
  "const-hex",
- "ethers-contract-abigen",
- "ethers-core",
+ "ethers-contract-abigen 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.40",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "ethers-contract-abigen 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -3284,13 +3366,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-core"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "arrayvec 0.7.4",
+ "bytes",
+ "cargo_metadata 0.18.1",
+ "chrono",
+ "const-hex",
+ "elliptic-curve",
+ "ethabi",
+ "generic-array 0.14.7",
+ "k256",
+ "num_enum 0.7.1",
+ "once_cell",
+ "open-fastrlp",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "serde_json",
+ "strum 0.25.0",
+ "syn 2.0.40",
+ "tempfile",
+ "thiserror",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
 name = "ethers-etherscan"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abbac2c890bdbe0f1b8e549a53b00e2c4c1de86bb077c1094d1f38cdf9381a56"
 dependencies = [
  "chrono",
- "ethers-core",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest",
+ "semver 1.0.20",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "chrono",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "reqwest",
  "semver 1.0.20",
  "serde",
@@ -3307,11 +3433,37 @@ checksum = "681ece6eb1d10f7cf4f873059a77c04ff1de4f35c63dd7bccde8f438374fcb93"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
+ "ethers-contract 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-etherscan 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-etherscan 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-providers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-signers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "futures-channel",
  "futures-locks",
  "futures-util",
@@ -3338,7 +3490,43 @@ dependencies = [
  "bytes",
  "const-hex",
  "enr",
- "ethers-core",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "http",
+ "instant",
+ "jsonwebtoken",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.5",
+ "bytes",
+ "const-hex",
+ "enr",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -3375,7 +3563,25 @@ dependencies = [
  "const-hex",
  "elliptic-curve",
  "eth-keystore",
- "ethers-core",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.8.5",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "const-hex",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror",
@@ -3392,7 +3598,38 @@ dependencies = [
  "const-hex",
  "dirs",
  "dunce",
- "ethers-core",
+ "ethers-core 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.20",
+ "serde",
+ "serde_json",
+ "solang-parser",
+ "svm-rs",
+ "thiserror",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.11"
+source = "git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107#f0e5b194f09c533feb10d1a686ddb9e5946ec107"
+dependencies = [
+ "cfg-if",
+ "const-hex",
+ "dirs",
+ "dunce",
+ "ethers-core 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "glob",
  "home",
  "md-5",
@@ -6025,7 +6262,7 @@ dependencies = [
  "async-trait",
  "blockifier",
  "clap 4.4.11",
- "ethers",
+ "ethers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-system",
@@ -6251,7 +6488,7 @@ dependencies = [
  "celestia-rpc",
  "celestia-types",
  "clap 4.4.11",
- "ethers",
+ "ethers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "futures",
  "jsonrpsee 0.20.3",
  "log",
@@ -6278,7 +6515,7 @@ dependencies = [
 name = "mc-db"
 version = "0.6.0"
 dependencies = [
- "ethers",
+ "ethers 2.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-rocksdb",
  "log",
  "parity-db",
@@ -6309,7 +6546,7 @@ dependencies = [
 name = "mc-l1-messages"
 version = "0.1.0"
 dependencies = [
- "ethers",
+ "ethers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "log",
  "mc-db",
  "mp-felt",
@@ -6433,7 +6670,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap 4.4.11",
- "ethers",
+ "ethers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "futures",
  "futures-timer",
  "log",
@@ -12085,8 +12322,8 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "ethers",
- "ethers-solc",
+ "ethers 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
+ "ethers-solc 2.0.11 (git+https://github.com/gakonst/ethers-rs?rev=f0e5b194f09c533feb10d1a686ddb9e5946ec107)",
  "flate2",
  "home",
  "madara-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,9 +227,12 @@ cairo-lang-casm-contract-class = { git = "https://github.com/keep-starknet-stran
 cairo-lang-casm = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support-8bbf530", default-features = false }
 cairo-lang-utils = { git = "https://github.com/keep-starknet-strange/cairo.git", branch = "no_std-support-8bbf530", default-features = false }
 
+# Ethers: using the same versions as in Anvil
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+ethers-solc = { git = "https://github.com/gakonst/ethers-rs", rev = "f0e5b194f09c533feb10d1a686ddb9e5946ec107" }
+
 # Other third party dependencies
 anyhow = "1.0.75"
-ethers = "2.0.7"
 flate2 = "1.0.28"
 scale-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
 parity-scale-codec = { version = "3.2.2", default-features = false }

--- a/crates/client/settlement/src/sync_state.rs
+++ b/crates/client/settlement/src/sync_state.rs
@@ -273,8 +273,6 @@ where
             config_hash,
             messages_to_l1,
             messages_to_l2,
-            // TODO: get values for state_updates and contract_class_diff too
-            ..Default::default()
         };
         log::trace!("{:#?}", program_output);
 

--- a/crates/node/src/commands/setup.rs
+++ b/crates/node/src/commands/setup.rs
@@ -164,7 +164,7 @@ impl SetupCmd {
         };
 
         let configs_file_content = config_source.load_config()?;
-        // Make sure it is valid data before writing it to disck
+        // Make sure it is valid data before writing it to disk
         let configs: configs::Configs =
             serde_json::from_slice(&configs_file_content).map_err(|e| Error::Application(Box::new(e)))?;
         write_content_to_disk(configs_file_content, dest_config_dir_path.join("index.json").as_path())?;

--- a/crates/primitives/snos-output/Cargo.toml
+++ b/crates/primitives/snos-output/Cargo.toml
@@ -18,6 +18,7 @@ sp-core = { workspace = true }
 starknet_api = { workspace = true }
 
 [dev-dependencies]
+pretty_assertions = { workspace = true }
 assert_matches = "1.5.0"
 hex = "*"
 

--- a/crates/primitives/snos-output/src/lib.rs
+++ b/crates/primitives/snos-output/src/lib.rs
@@ -36,8 +36,4 @@ pub struct StarknetOsOutput {
     pub messages_to_l1: Vec<MessageL2ToL1>,
     /// List of messages from L1 handled in this block
     pub messages_to_l2: Vec<MessageL1ToL2>,
-    /// List of the storage updates.
-    pub state_updates: Vec<StarkFelt>,
-    /// List of the newly declared contract classes.
-    pub contract_class_diff: Vec<StarkFelt>,
 }

--- a/crates/primitives/snos-output/src/tests.rs
+++ b/crates/primitives/snos-output/src/tests.rs
@@ -49,7 +49,7 @@ fn test_snos_output_codec() {
     let mut actual: Vec<u8> = Vec::new();
     snos_output.into_encoded_vec().into_iter().for_each(|felt| actual.extend_from_slice(felt.0.as_slice()));
 
-    assert_eq!(output_bytes, actual);
+    pretty_assertions::assert_eq!(output_bytes, actual);
 }
 
 #[test]

--- a/madara-test-runner/src/node.rs
+++ b/madara-test-runner/src/node.rs
@@ -87,15 +87,12 @@ impl MadaraNode {
             if let Some(bp) = &base_path_arg {
                 setup_args.push(bp);
             };
-            if let Some(s) = &settlement_arg {
-                setup_args.push(s);
-            };
 
             let setup_res =
                 Self::cargo_run(repository_root.as_path(), setup_args).wait().expect("Failed to setup Madara node");
 
             if !setup_res.success() {
-                panic!("Madara setup failed");
+                panic!("Madara setup failed with {} (check out stderr logs)", setup_res.to_string());
             }
         }
 

--- a/starknet-e2e-test/Cargo.toml
+++ b/starknet-e2e-test/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 anyhow = "1.0.72"
 assert_matches = "1.5.0"
 async-trait = "0.1"
-ethers = { workspace = true }
-ethers-solc = "2.0.7"
 flate2 = { workspace = true }
 home = "0.5.5"
 reqwest = "0.11.18"
@@ -20,6 +18,8 @@ test-context = "0.1.3"
 thiserror = { workspace = true }
 tokio = { version = "1.29.1", features = ["rt", "macros", "parking_lot"] }
 url = "2.4.1"
+ethers = { workspace = true }
+ethers-solc = { workspace = true }
 
 # Starknet
 starknet-accounts = { workspace = true }

--- a/starknet-e2e-test/README.md
+++ b/starknet-e2e-test/README.md
@@ -115,3 +115,6 @@ By default, integration tests involving Ethereum contracts will try to find
 Anvil at `~/.foundry/bin/anvil`.  
 Alternatively you can specify the Anvil binary location by setting `ANVIL_PATH`
 environment variable.
+
+IMPORTANT: make sure your Anvil version uses a compatiuble `ethers-rs` library version.  
+In case of an issue, try to update both dependencies first.

--- a/starknet-e2e-test/ethereum_core_contract.rs
+++ b/starknet-e2e-test/ethereum_core_contract.rs
@@ -3,8 +3,10 @@ extern crate starknet_e2e_test;
 use madara_runtime::opaque::Block;
 use mc_settlement::ethereum::StarknetContractClient;
 use mc_settlement::{SettlementProvider, StarknetSpec, StarknetState};
-use mp_snos_output::{MessageL1ToL2, MessageL2ToL1, StarknetOsOutput};
+use mp_messages::{MessageL1ToL2, MessageL2ToL1};
+use mp_snos_output::StarknetOsOutput;
 use rstest::rstest;
+use starknet_api::api_core::{ContractAddress, Nonce, PatriciaKey};
 use starknet_api::hash::StarkFelt;
 use starknet_e2e_test::ethereum_sandbox::EthereumSandbox;
 use starknet_e2e_test::starknet_contract::{InitData, StarknetContract};
@@ -70,9 +72,9 @@ async fn starknet_core_contract_sends_messages_to_l2() -> anyhow::Result<()> {
     from_address[12..32].copy_from_slice(sandbox.address().as_bytes());
 
     let message = MessageL1ToL2 {
-        from_address: StarkFelt::new(from_address).unwrap(),
+        from_address: ContractAddress(PatriciaKey(StarkFelt::new(from_address).unwrap())),
         to_address: 3u64.into(),
-        nonce: 0u64.into(), // Starknet contract maintains global nonce counter
+        nonce: Nonce(0u64.into()), // Starknet contract maintains global nonce counter
         selector: 2u64.into(),
         payload: vec![1u64.into()],
     };
@@ -111,7 +113,11 @@ async fn starknet_core_contract_consumes_messages_from_l2() -> anyhow::Result<()
 
     starknet_contract.initialize(&sandbox, InitData::one()).await;
 
-    let message = MessageL2ToL1 { from_address: 1u64.into(), to_address: 2u64.into(), payload: vec![3u64.into()] };
+    let message = MessageL2ToL1 {
+        from_address: 1u64.into(),
+        to_address: StarkFelt::from(2u64).try_into().unwrap(),
+        payload: vec![3u64.into()],
+    };
     let starknet = StarknetContractClient::new(starknet_contract.address(), sandbox.client());
 
     let program_output = StarknetOsOutput {


### PR DESCRIPTION
There are several issues with the snos codec that break tests:
1. `size_in_felts` in snos codec is not an approximation like in scale, but an exact number - it is used to calculate the segment size (which is encoded as well).
2. OS output has two parts: main and data availability (state updates and contract code diffs). Core contract accepts main part encoded (this is what is currently implemented in snos codec) and two additional args - hash and size of the DA part. DA part is supposed to be submitted to the pages registry contract.